### PR TITLE
Rework code to be more flexible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ all of which should be in this repository.
 
 If you want to report a bug or request a new feature, the most direct
 method is to [create an
-issue](https://github.com/cisagov/vpc-with-distributed-subnets-tf-module/issues)
+issue](https://github.com/cisagov/distributed-subnets-tf-module/issues)
 in this repository.  We recommend that you first search through
 existing issues (both open and closed) to check if your particular
 issue has already been reported.  If it has then you might want to add
@@ -25,7 +25,7 @@ create a new one.
 ## Pull requests ##
 
 If you choose to [submit a pull
-request](https://github.com/cisagov/vpc-with-distributed-subnets-tf-module/pulls),
+request](https://github.com/cisagov/distributed-subnets-tf-module/pulls),
 you will notice that our continuous integration (CI) system runs a
 fairly extensive set of linters and syntax checkers.  Your pull
 request may fail these checks, and that's OK.  If you want you can
@@ -78,9 +78,9 @@ can create and configure the Python virtual environment with these
 commands:
 
 ```console
-cd vpc-with-distributed-subnets-tf-module
-pyenv virtualenv <python_version_to_use> vpc-with-distributed-subnets-tf-module
-pyenv local vpc-with-distributed-subnets-tf-module
+cd distributed-subnets-tf-module
+pyenv virtualenv <python_version_to_use> distributed-subnets-tf-module
+pyenv local distributed-subnets-tf-module
 pip install -r requirements-dev.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# vpc-with-distributed-subnets-tf-module #
+# distributed-subnets-tf-module #
 
 [![GitHub Build
-Status](https://github.com/cisagov/vpc-with-distributed-subnets-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/vpc-with-distributed-subnets-tf-module/actions)
+Status](https://github.com/cisagov/distributed-subnets-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/distributed-subnets-tf-module/actions)
 
-A Terraform module that creates a VPC with one or more subnets.  The
+A Terraform module that creates one or more subnets inside a VPC.  The
 subnets are automatically distributed across the availability zones in
-the region where the VPC is being deployed.
+the region where the VPC is deployed.
 
 ## Usage ##
 
 ```hcl
-module "vpc" {
-  source = "github.com/cisagov/vpc-with-distributed-subnets-tf-module"
+module "subnets" {
+  source = "github.com/cisagov/distributed-subnets-tf-module"
 
-  cidr_block = "10.10.0.0/16"
+  vpc_id = "vpc-0123456789abcdef0"
   subnet_cidr_blocks = [
     "10.10.1.0/24",
     "10.10.2.0/24",
@@ -27,13 +27,13 @@ module "vpc" {
 
 ## Examples ##
 
-* [Basic usage](https://github.com/cisagov/vpc-with-distributed-subnets-tf-module/tree/develop/examples/basic_usage)
+* [Basic usage](https://github.com/cisagov/distributed-subnets-tf-module/tree/develop/examples/basic_usage)
 
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| cidr_block | The CIDR block associated with the VPC (e.g. "10.10.0.0/16") | string | | yes |
+| vpc_id | The ID of the VPC where the subnets are to be created (e.g. "vpc-0123456789abcdef0") | string | | yes |
 | subnet_cidr_blocks | A list of the CIDR blocks associated with the individual subnets in the VPC (e.g. ["10.10.0.0/16", "10.11.0.0/16""]).  Note that the CIDR blocks in this list must be contained within the larger CIDR block associated with the VPC, and they must not overlap. | list(string) | | yes |
 | tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
 
@@ -41,7 +41,6 @@ module "vpc" {
 
 | Name | Description |
 |------|-------------|
-| vpc_id | The VPC ID |
 | subnet_ids | The subnet IDs |
 
 ## Contributing ##

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -1,4 +1,4 @@
-# Basic Usage of the VPC-With-Distributed-Subnets Terraform Module #
+# Basic Usage of the Distributed-Subnets Terraform Module #
 
 ## Usage ##
 
@@ -13,4 +13,5 @@ Note that this example may create resources which cost money. Run
 | Name | Description |
 |------|-------------|
 | vpc_id | The VPC ID  |
-| subnet_ids | The subnet IDs |
+| private_subnet_ids | The private subnet IDs |
+| public_subnet_ids | The public subnet IDs |

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -3,16 +3,36 @@ provider "aws" {
 }
 
 #-------------------------------------------------------------------------------
+# Create a VPC.
+#-------------------------------------------------------------------------------
+resource "aws_vpc" "the_vpc" {
+  cidr_block           = "10.23.0.0/16"
+  enable_dns_hostnames = true
+}
+
+#-------------------------------------------------------------------------------
 # Configure the module.
 #-------------------------------------------------------------------------------
-module "vpc" {
+module "private_subnets" {
   source = "../../"
 
-  cidr_block = "10.23.0.0/16"
+  vpc_id = aws_vpc.the_vpc.id
   # There are only two AZs in us-west-1, so there will be two subnets
   # in one AZ and one on its own
   subnet_cidr_blocks = [
     for num in range(3) :
-    cidrsubnet("10.23.0.0/16", 8, num)
+    cidrsubnet("10.23.0.0/17", 7, num)
+  ]
+}
+
+module "public_subnets" {
+  source = "../../"
+
+  vpc_id = aws_vpc.the_vpc.id
+  # There are only two AZs in us-west-1, so there will be two subnets
+  # in one AZ and one on its own
+  subnet_cidr_blocks = [
+    for num in range(3) :
+    cidrsubnet("10.23.128.0/17", 7, num)
   ]
 }

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -1,9 +1,14 @@
 output "vpc_id" {
-  value       = module.vpc.vpc_id
+  value       = aws_vpc.the_vpc.id
   description = "The VPC ID"
 }
 
-output "subnet_ids" {
-  value       = module.vpc.subnet_ids
-  description = "The subnet IDs"
+output "private_subnet_ids" {
+  value       = module.private_subnets.subnet_ids
+  description = "The private subnet IDs"
+}
+
+output "public_subnet_ids" {
+  value       = module.public_subnets.subnet_ids
+  description = "The public subnet IDs"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "vpc_id" {
-  value       = aws_vpc.the_vpc.id
-  description = "The VPC ID"
-}
-
 output "subnet_ids" {
   value       = aws_subnet.the_subnets[*].id
   description = "The subnet IDs"

--- a/subnets.tf
+++ b/subnets.tf
@@ -11,6 +11,6 @@ resource "aws_subnet" "the_subnets" {
   # behavior we want.
   availability_zone_id = element(data.aws_availability_zones.the_azs.zone_ids, count.index)
   cidr_block           = var.subnet_cidr_blocks[count.index]
-  vpc_id               = aws_vpc.the_vpc.id
+  vpc_id               = var.vpc_id
   tags                 = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,8 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "cidr_block" {
-  description = "The CIDR block associated with the VPC (e.g. \"10.10.0.0/16\")"
+variable "vpc_id" {
+  description = "The ID of the VPC where the subnets are to be created (e.g. \"vpc-0123456789abcdef0\")"
 }
 
 variable "subnet_cidr_blocks" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,9 +1,0 @@
-# ------------------------------------------------------------------------------
-# Create the VPC
-# ------------------------------------------------------------------------------
-
-resource "aws_vpc" "the_vpc" {
-  cidr_block           = var.cidr_block
-  enable_dns_hostnames = true
-  tags                 = var.tags
-}


### PR DESCRIPTION
## 🗣 Description

Rework the Terraform module code to be more flexible.  Instead of creating the VPC inside the module, the user instead specifies the VPC ID in which the subnets should be deployed.  This is more flexible, since it allows the user to create multiple sets of distributed subnets - public and private, for instance - inside the same VPC.

## 💭 Motivation and Context

The shared services account VPC requires this.  The FreeIPA master and replicas will be scattered among a set of _private_ subnets distributed across AZs, while the OpenVPN instances will be scattered among a set of _public_ subnets distributed across AZs. 

## 🧪 Testing

I deployed the example code, and it appears to perform exactly as intended.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
