### PR TITLE
Use for_each instead of count

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ module "subnets" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| vpc_id | The ID of the VPC where the subnets are to be created (e.g. "vpc-0123456789abcdef0") | string | | yes |
+| vpc_id | The ID of the VPC where the subnets are to be created (e.g. "vpc-0123456789abcdef0"). | string | | yes |
 | subnet_cidr_blocks | A list of the CIDR blocks associated with the individual subnets in the VPC (e.g. ["10.10.0.0/16", "10.11.0.0/16""]).  Note that the CIDR blocks in this list must be contained within the larger CIDR block associated with the VPC, and they must not overlap. | list(string) | | yes |
-| tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
+| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| subnet_ids | The subnet IDs |
+| subnets | A map with keys equal to the subnet CIDR blocks and values equal to the subnets. |
 
 ## Contributing ##
 

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -12,6 +12,6 @@ Note that this example may create resources which cost money. Run
 
 | Name | Description |
 |------|-------------|
-| vpc_id | The VPC ID  |
-| private_subnet_ids | The private subnet IDs |
-| public_subnet_ids | The public subnet IDs |
+| vpc | The VPC.  |
+| private_subnets | The private subnets. |
+| public_subnets | The public subnets. |

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -1,14 +1,14 @@
-output "vpc_id" {
-  value       = aws_vpc.the_vpc.id
-  description = "The VPC ID"
+output "vpc" {
+  value       = aws_vpc.the_vpc
+  description = "The VPC"
 }
 
-output "private_subnet_ids" {
-  value       = module.private_subnets.subnet_ids
-  description = "The private subnet IDs"
+output "private_subnets" {
+  value       = module.private_subnets.subnets
+  description = "The private subnets"
 }
 
-output "public_subnet_ids" {
-  value       = module.public_subnets.subnet_ids
-  description = "The public subnet IDs"
+output "public_subnets" {
+  value       = module.public_subnets.subnets
+  description = "The public subnets"
 }

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -1,14 +1,14 @@
 output "vpc" {
   value       = aws_vpc.the_vpc
-  description = "The VPC"
+  description = "The VPC."
 }
 
 output "private_subnets" {
   value       = module.private_subnets.subnets
-  description = "The private subnets"
+  description = "The private subnets."
 }
 
 output "public_subnets" {
   value       = module.public_subnets.subnets
-  description = "The public subnets"
+  description = "The public subnets."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "subnet_ids" {
-  value       = aws_subnet.the_subnets[*].id
-  description = "The subnet IDs"
+output "subnets" {
+  value       = aws_subnet.the_subnets
+  description = "A map with keys equal to the subnet CIDR blocks and values equal to the subnets."
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -4,13 +4,13 @@
 # ------------------------------------------------------------------------------
 
 resource "aws_subnet" "the_subnets" {
-  count = length(var.subnet_cidr_blocks)
+  for_each = toset(var.subnet_cidr_blocks)
 
   # We use element(x, i) instead of x[i] because, when i > length(x),
   # then element() returns x[i % length(x)].  This is precisely the
   # behavior we want.
-  availability_zone_id = element(data.aws_availability_zones.the_azs.zone_ids, count.index)
-  cidr_block           = var.subnet_cidr_blocks[count.index]
+  availability_zone_id = element(data.aws_availability_zones.the_azs.zone_ids, index(var.subnet_cidr_blocks, each.value))
+  cidr_block           = each.value
   vpc_id               = var.vpc_id
   tags                 = var.tags
 }


### PR DESCRIPTION
## 🗣 Description

In this pull request I:
* Use `for_each` instead of `count`.  This way we can add/remove/modify subnets without having to recreate them all.
* Return actual resources as outputs instead of just IDs.  Terraform allows you to do this now, and I think it makes a lot more sense.  The user can grab the ID, name, or any other attribute he or she needs instead of using a data resource.

## 💭 Motivation and Context

Having to destroy all resources generated by `count` just to add a new one is painful.  Let's stop doing that.

## 🧪 Testing

I deployed the example code to make sure everything is working.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
