### PR TITLE
Blacklist use1-az3

### DIFF
--- a/azs.tf
+++ b/azs.tf
@@ -1,5 +1,11 @@
 # The availability zones available to the provider being used
 data "aws_availability_zones" "the_azs" {
+  blacklisted_zone_ids = [
+    # There are no modern instance types in use1-az3; AWS has left
+    # that zone behind for the most part.  See, for example, here:
+    # https://www.reddit.com/r/aws/comments/g5lh7h/t3m5r5_instance_types_in_use1az3/
+    "use1-az3",
+  ]
   state = "available"
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request blacklists the `use1-az3` AZ.

## 💭 Motivation and Context

[There are no modern instance types in `use1-az3`](https://www.reddit.com/r/aws/comments/g5lh7h/t3m5r5_instance_types_in_use1az3/); AWS has left that zone behind for the most part.  For example, there are no t3 instances in that AZ.

## 🧪 Testing

I ran into this issue when deploying [cisagov/cool-sharedservices-freeipa](cisagov/cool-sharedservices-freeipa).  Without this change I was unable to create a `t3.medium` instance for one of the private subnets of [cisagov/cool-sharedservices-networking](https://github.com/cisagov/cool-sharedservices-networking).  With the change I was able to do it.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
